### PR TITLE
Add migration file for upgrades from 1.3.0 to 1.3.1

### DIFF
--- a/src/sql/upgrade/20200907_from_1.3.0_to_1.3.1.sql
+++ b/src/sql/upgrade/20200907_from_1.3.0_to_1.3.1.sql
@@ -1,0 +1,1 @@
+UPDATE Baobab_Errors SET msg="1.3.1" WHERE code=1000;


### PR DESCRIPTION
When upgrading from 1.3.0 to 1.3.1 you get an error saying
```[VERSION_NOT_MATCH] The library and the sql schema have different versions (database tables v. 1.3.0, library v. 1.3.1). Please use Baobab::upgrade().```

Since this version is a minor upgrade, only the `VERSION` number in the `Baobab_Errors` table should be updated to 1.3.1.